### PR TITLE
Fix key bindings message

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -62,8 +62,8 @@ Finally add this to your Emacs config:
 
 ```el
 (projectile-mode +1)
-(define-key projectile-mode-map (kbd "s-p") 'projectile-command-map)
-(define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map)
+(define-key map (kbd "s-p") 'projectile-command-map)
+(define-key map (kbd "C-c p") 'projectile-command-map)
 ```
 
 Those keymap prefixes are just a suggestion. Feel free to put there whatever works best for you.


### PR DESCRIPTION
Key bindings are not working using the previous command. 
Users of prelude should see the prelude-mode.el file in their .emacs.d/core/prelude-model.el file. This contains the line:

;; extra prefix for projectile
(define-key map (kbd "s-p") 'projectile-command-map)

and this is where I took the commands above from.